### PR TITLE
Ignore E741 for now

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ commands =
 # E123, E125 skipped as they are invalid PEP-8.
 
 show-source = True
-ignore = E123,E125,E402,W503
+ignore = E123,E125,E402,E741,W503
 max-line-length = 160
 builtins = _
 exclude = .git,.tox


### PR DESCRIPTION
Once we start development on our collections, we'll remove this. For
now, it means we don't have to refactor a lot of code in
ansible/ansible.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>