### PR TITLE
Remove version number from galaxy.yaml

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -6,4 +6,3 @@ name: ios
 namespace: cisco
 readme: README.rst
 repository: https://github.com/ansible-network/ansible_collections.cisco.ios
-version: 0.0.1


### PR DESCRIPTION
We dynamically generate our version number in our release jobs, this is
no longer needed.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>